### PR TITLE
Add modular pipeline skeleton

### DIFF
--- a/forest_test/core/__init__.py
+++ b/forest_test/core/__init__.py
@@ -1,0 +1,12 @@
+from .registry import DetectorRegistry, register_detector
+from .pipeline import Vectorizer
+from .dataset import Dataset
+from .mixer import RandomForestMixer
+
+__all__ = [
+    "DetectorRegistry",
+    "register_detector",
+    "Vectorizer",
+    "Dataset",
+    "RandomForestMixer",
+]

--- a/forest_test/core/dataset.py
+++ b/forest_test/core/dataset.py
@@ -1,0 +1,13 @@
+from typing import Iterable, Tuple
+import pandas as pd
+
+
+class Dataset:
+    def __init__(self, csv_path: str, img_col: str = "file_name", label_col: str = "category"):
+        self.df = pd.read_csv(csv_path)
+        self.img_col = img_col
+        self.label_col = label_col
+
+    def __iter__(self) -> Iterable[Tuple[str, str]]:
+        for _, row in self.df.iterrows():
+            yield row[self.img_col], row[self.label_col]

--- a/forest_test/core/mixer.py
+++ b/forest_test/core/mixer.py
@@ -1,0 +1,13 @@
+import numpy as np
+from sklearn.ensemble import RandomForestClassifier
+
+
+class RandomForestMixer:
+    def __init__(self, **params):
+        self.model = RandomForestClassifier(**params)
+
+    def fit(self, X: np.ndarray, y: np.ndarray):
+        self.model.fit(X, y)
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        return self.model.predict(X)

--- a/forest_test/core/pipeline.py
+++ b/forest_test/core/pipeline.py
@@ -1,0 +1,17 @@
+from typing import List, Dict, Any
+import numpy as np
+from .registry import DetectorRegistry
+
+
+class Vectorizer:
+    def __init__(self, detector_names: List[str]):
+        self.detectors = [DetectorRegistry.create(name) for name in detector_names]
+
+    def __call__(self, local: Dict[str, Any]) -> np.ndarray:
+        vecs = []
+        for det in self.detectors:
+            det(local)
+            vecs.append(det.vec)
+        if vecs:
+            return np.hstack(vecs)
+        return np.array([])

--- a/forest_test/core/registry.py
+++ b/forest_test/core/registry.py
@@ -1,0 +1,19 @@
+class DetectorRegistry:
+    _registry = {}
+
+    @classmethod
+    def register(cls, name, detector_cls):
+        cls._registry[name] = detector_cls
+
+    @classmethod
+    def create(cls, name, *args, **kwargs):
+        if name not in cls._registry:
+            raise ValueError(f"Detector '{name}' not registered")
+        return cls._registry[name](*args, **kwargs)
+
+
+def register_detector(name):
+    def decorator(cls):
+        DetectorRegistry.register(name, cls)
+        return cls
+    return decorator

--- a/forest_test/pipeline_example.py
+++ b/forest_test/pipeline_example.py
@@ -1,0 +1,23 @@
+from core import register_detector, Vectorizer, RandomForestMixer, Dataset
+import numpy as np
+
+
+@register_detector("dummy")
+class DummyDetector:
+    def __init__(self):
+        self.stopvec = np.array([1])
+        self._vec = np.zeros(1)
+
+    @property
+    def vec(self):
+        return self._vec
+
+    def __call__(self, local):
+        self._vec[0] = 1.0 if local.get("flag") else 0.0
+
+
+if __name__ == "__main__":
+    vec = Vectorizer(["dummy"])
+    local = {"flag": True}
+    x = vec(local)
+    print("Vector:", x)

--- a/forest_test/utils/data_metrics.py
+++ b/forest_test/utils/data_metrics.py
@@ -241,7 +241,7 @@ def report(test_ctgr, metrics, importance=None, dataset="ds_russ2024y", comment=
     }
     
     os.makedirs(f'{pref}', exist_ok=True)
-    json_file_path = f"{pref}/{dataset}-{pipe_str.replace("->", "_")}{suf}.json"
+    json_file_path = f"{pref}/{dataset}-{pipe_str.replace('->', '_')}{suf}.json"
     with open(json_file_path, 'w', encoding='utf-8') as json_file:
         json.dump(report_dict, json_file, ensure_ascii=False, indent=4)
         


### PR DESCRIPTION
## Summary
- add core package with plugin registry and pipeline helpers
- provide dataset helper and random forest mixer
- fix quoting bug in data_metrics
- show example usage in `pipeline_example.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684005a85484832f88a3e57b11480dec