### PR TITLE
Refactor detectors and add example configs

### DIFF
--- a/forest_test/core/__init__.py
+++ b/forest_test/core/__init__.py
@@ -1,0 +1,12 @@
+from .registry import DetectorRegistry, register_detector
+from .pipeline import Vectorizer
+from .dataset import Dataset
+from .mixer import RandomForestMixer
+
+__all__ = [
+    "DetectorRegistry",
+    "register_detector",
+    "Vectorizer",
+    "Dataset",
+    "RandomForestMixer",
+]

--- a/forest_test/core/dataset.py
+++ b/forest_test/core/dataset.py
@@ -1,0 +1,13 @@
+from typing import Iterable, Tuple
+import pandas as pd
+
+
+class Dataset:
+    def __init__(self, csv_path: str, img_col: str = "file_name", label_col: str = "category"):
+        self.df = pd.read_csv(csv_path)
+        self.img_col = img_col
+        self.label_col = label_col
+
+    def __iter__(self) -> Iterable[Tuple[str, str]]:
+        for _, row in self.df.iterrows():
+            yield row[self.img_col], row[self.label_col]

--- a/forest_test/core/mixer.py
+++ b/forest_test/core/mixer.py
@@ -1,0 +1,13 @@
+import numpy as np
+from sklearn.ensemble import RandomForestClassifier
+
+
+class RandomForestMixer:
+    def __init__(self, **params):
+        self.model = RandomForestClassifier(**params)
+
+    def fit(self, X: np.ndarray, y: np.ndarray):
+        self.model.fit(X, y)
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        return self.model.predict(X)

--- a/forest_test/core/pipeline.py
+++ b/forest_test/core/pipeline.py
@@ -1,0 +1,17 @@
+from typing import List, Dict, Any
+import numpy as np
+from .registry import DetectorRegistry
+
+
+class Vectorizer:
+    def __init__(self, detector_names: List[str]):
+        self.detectors = [DetectorRegistry.create(name) for name in detector_names]
+
+    def __call__(self, local: Dict[str, Any]) -> np.ndarray:
+        vecs = []
+        for det in self.detectors:
+            det(local)
+            vecs.append(det.vec)
+        if vecs:
+            return np.hstack(vecs)
+        return np.array([])

--- a/forest_test/core/registry.py
+++ b/forest_test/core/registry.py
@@ -1,0 +1,19 @@
+class DetectorRegistry:
+    _registry = {}
+
+    @classmethod
+    def register(cls, name, detector_cls):
+        cls._registry[name] = detector_cls
+
+    @classmethod
+    def create(cls, name, *args, **kwargs):
+        if name not in cls._registry:
+            raise ValueError(f"Detector '{name}' not registered")
+        return cls._registry[name](*args, **kwargs)
+
+
+def register_detector(name):
+    def decorator(cls):
+        DetectorRegistry.register(name, cls)
+        return cls
+    return decorator

--- a/forest_test/examples/main_andrey_05_03.py
+++ b/forest_test/examples/main_andrey_05_03.py
@@ -1,0 +1,28 @@
+from core import Vectorizer, RandomForestMixer, register_detector, Dataset
+from yolo.olga import Kat_05_03 as Yolo05_03Base
+from ocr.andrey import Kat_05_03 as Ocr05_03Base
+
+@register_detector("yolo_05_03")
+class Yolo05_03(Yolo05_03Base):
+    pass
+
+@register_detector("ocr_05_03")
+class Ocr05_03(Ocr05_03Base):
+    pass
+
+CONFIG = {
+    "detectors": ["yolo_05_03", "ocr_05_03"],
+    "dataset_csv": "path/to/labels_05_03.csv",
+    "mixer_params": {"n_estimators": 100, "random_state": 42}
+}
+
+if __name__ == "__main__":
+    vectorizer = Vectorizer(CONFIG["detectors"])
+    mixer = RandomForestMixer(**CONFIG["mixer_params"])
+    ds = Dataset(CONFIG["dataset_csv"])
+    for img_path, label in ds:
+        # Обычно здесь подготавливают 'local' с картинкой и текстом
+        local = {"img": None, "txt": ""}
+        x = vectorizer(local)
+        print("Sample vector", x)
+        break

--- a/forest_test/examples/main_andrey_28_08.py
+++ b/forest_test/examples/main_andrey_28_08.py
@@ -1,0 +1,27 @@
+from core import Vectorizer, RandomForestMixer, register_detector, Dataset
+from yolo.olga import Kat_28_08 as Yolo28_08Base
+from ocr.andrey import Kat_28_08 as Ocr28_08Base
+
+@register_detector("yolo_28_08")
+class Yolo28_08(Yolo28_08Base):
+    pass
+
+@register_detector("ocr_28_08")
+class Ocr28_08(Ocr28_08Base):
+    pass
+
+CONFIG = {
+    "detectors": ["yolo_28_08", "ocr_28_08"],
+    "dataset_csv": "path/to/labels_28_08.csv",
+    "mixer_params": {"n_estimators": 100, "random_state": 42}
+}
+
+if __name__ == "__main__":
+    vectorizer = Vectorizer(CONFIG["detectors"])
+    mixer = RandomForestMixer(**CONFIG["mixer_params"])
+    ds = Dataset(CONFIG["dataset_csv"])
+    for img_path, label in ds:
+        local = {"img": None, "txt": ""}
+        x = vectorizer(local)
+        print("Sample vector", x)
+        break

--- a/forest_test/ocr/andrey.py
+++ b/forest_test/ocr/andrey.py
@@ -1,3 +1,4 @@
+from core import register_detector
 from .ocrdetector import OcrDetector
 
 
@@ -37,6 +38,7 @@ class Kat_05_01 (OcrDetector):
 # пустая категория: 05.02 Иностранные слова
 # --------------------------------------------------------------------------------
 
+@register_detector("ocr_kat_05_03")
 class Kat_05_03 (OcrDetector):
     def __init__(self):
         super().__init__(
@@ -200,6 +202,7 @@ class Kat_28_14 (OcrDetector):
             filename="ocr.txt"
         )
         
+@register_detector("ocr_kat_28_08")
 class Kat_28_08 (OcrDetector):
     def __init__(self):
         super().__init__(

--- a/forest_test/utils/data_metrics.py
+++ b/forest_test/utils/data_metrics.py
@@ -241,7 +241,7 @@ def report(test_ctgr, metrics, importance=None, dataset="ds_russ2024y", comment=
     }
     
     os.makedirs(f'{pref}', exist_ok=True)
-    json_file_path = f"{pref}/{dataset}-{pipe_str.replace("->", "_")}{suf}.json"
+    json_file_path = f"{pref}/{dataset}-{pipe_str.replace('->', '_')}{suf}.json"
     with open(json_file_path, 'w', encoding='utf-8') as json_file:
         json.dump(report_dict, json_file, ensure_ascii=False, indent=4)
         

--- a/forest_test/yolo/olga.py
+++ b/forest_test/yolo/olga.py
@@ -1,5 +1,6 @@
 from typing import Dict, Any
 import numpy as np
+from core import register_detector
 from .yolodtc import YOLODetector
 
 
@@ -33,6 +34,7 @@ class Kat_02_05(YOLODetector):
         )
         
 
+@register_detector("yolo_kat_05_03")
 class Kat_05_03(YOLODetector):
     def __init__(self):
         super().__init__(
@@ -63,6 +65,7 @@ class Kat_28_07(YOLODetector):
         )
        
 
+@register_detector("yolo_kat_28_08")
 class Kat_28_08(YOLODetector):
     def __init__(self):
         super().__init__(


### PR DESCRIPTION
## Summary
- register OCR and YOLO detectors for categories 05_03 and 28_08
- drop obsolete `pipeline_example.py`
- provide example main files demonstrating configuration-based usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684005a85484832f88a3e57b11480dec